### PR TITLE
feat: Add OpenAPI spec, Scalar UI, and /v1/* version aliases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,13 @@ There is no test project in the solution.
 
 ## Architecture
 
-ASP.NET Core (.NET 9) web API built on **FastEndpoints** that serves FAA CIFP-derived SIDs, STARs, and approaches as JSON. The hot data structure is the parsed ARINC 424 database produced by the `arinc424` NuGet package (`Data424`).
+ASP.NET Core (.NET 9) web API built on **FastEndpoints 8** that serves FAA CIFP-derived SIDs, STARs, approaches, and navigation-point lookups as JSON. The hot data structure is the parsed ARINC 424 database produced by the `arinc424` NuGet package (`Data424`).
 
 ### Data lifecycle (CIFP)
 
 The FAA CIFP data is the single source of truth and is loaded into memory at startup, then refreshed in the background:
 
-1. `CifpUpdateService` (Coravel `IInvocable`) is both registered with Coravel's scheduler in `Program.cs:26` (`.Hourly().RunOnceAtStart()`) **and** runs its own `while (!cancelled) { ...; await Task.Delay(1h) }` loop inside `Invoke` (`Services/CifpUpdateService.cs:19`). This is almost certainly a bug — the two hourly loops overlap and the scheduled invocation never returns. Pick one (likely drop the internal delay loop now that Coravel handles cadence) before relying on the update cadence.
+1. `CifpUpdateService` (Coravel `IInvocable`) is both registered with Coravel's scheduler in `Program.cs:51` (`.Hourly().RunOnceAtStart()`) **and** runs its own `while (!cancelled) { ...; await Task.Delay(1h) }` loop inside `Invoke` (`Services/CifpUpdateService.cs:19`). This is almost certainly a bug — the two hourly loops overlap and the scheduled invocation never returns. Pick one (likely drop the internal delay loop now that Coravel handles cadence) before relying on the update cadence.
 2. Each tick GETs `https://external-api.faa.gov/apra/cifp/chart`, deserializes the `ProductSet` XML (`Services/Models/CifpEdition.cs`), and compares the product URL against `_lastKnownUrl`. A new URL triggers a download + `ZipArchive` extraction of the `FAACIFP18` entry.
 3. Lines are streamed via `IAsyncEnumerable<string>` into `CifpService.UpdateCifp`, which immediately materializes them with `ToBlockingEnumerable().ToList()` (`Services/CifpService.cs:14`) before calling `Data424.Create(meta, ..., out skipped, out invalid)` with `Supplement.V18`. Don't assume the pipeline actually streams — it doesn't.
 4. `Data424.Create` also emits `skipped` (`string[]` of unrecognized line tokens) and `invalid` (`FrozenDictionary<Record424, Diagnostic[]>` of failed builds) that are stored on `CifpService` but currently never read or logged. Either surface them or drop the fields; don't leave them as dead state.
@@ -29,29 +29,38 @@ The FAA CIFP data is the single source of truth and is loaded into memory at sta
 ### Service lifetimes (important gotcha)
 
 - `CifpService` — **singleton**, holds the mutable `Data424?`.
-- `ArrivalService` / `DepartureService` / `ApproachService` — **scoped**, depend on `CifpService`. All three use primary constructors and dereference `cifpService.Data` lazily inside their `GetCombined*` methods, throwing if null.
-- Because the local-file fallback was removed, `cifpService.Data` is `null` until the first successful FAA fetch completes. Any request arriving in that window will throw — the three services surface it as a clean `Exception("CifpService data is null")` rather than an NPE, but the 500 response is the same either way. If you touch the load flow, preserve the invariant that `Data` is populated before the app starts serving, or add a proper 503 path.
+- `ArrivalService` / `DepartureService` / `ApproachService` / `PointService` — **scoped**, depend on `CifpService`. All four use primary constructors and dereference `cifpService.Data` lazily inside their `Get*` methods, throwing if null.
+- Because the local-file fallback was removed, `cifpService.Data` is `null` until the first successful FAA fetch completes. Any request arriving in that window will throw — the services surface it as a clean `Exception("CifpService data is null")` rather than an NPE, but the 500 response is the same either way. If you touch the load flow, preserve the invariant that `Data` is populated before the app starts serving, or add a proper 503 path.
 
 ### Endpoints
 
-FastEndpoints (v7) auto-discovers endpoint classes under `Endpoints/`. Current routes:
+FastEndpoints 8 auto-discovers endpoint classes under `Endpoints/`. Every route is registered twice — a bare path and a `/v1/` alias — so clients can opt into versioning without a breaking change. Current routes:
 
-- `GET /departures/{AirportId}` → `GetSidsEndpoint` → `DepartureService.GetCombinedDepartures` → `List<CombinedDeparture>`
-- `GET /arrivals/{AirportId}` → `GetStarsEndpoint` → `ArrivalService.GetCombinedArrivals` → `List<CombinedArrival>`
-- `GET /approaches/{AirportId}` → `GetApproachesEndpoint` → `ApproachService.GetCombinedApproaches` → `List<CombinedApproach>`
-- `GET /points/{Identifier}` → `GetPointEndpoint` → `PointService.GetPointsByIdentifier` → `List<PointLookupResult>`
+- `GET /departures/{AirportId}` (and `/v1/...`) → `GetSidsEndpoint` → `DepartureService.GetCombinedDepartures` → `List<CombinedDeparture>`
+- `GET /arrivals/{AirportId}` (and `/v1/...`) → `GetStarsEndpoint` → `ArrivalService.GetCombinedArrivals` → `List<CombinedArrival>`
+- `GET /approaches/{AirportId}` (and `/v1/...`) → `GetApproachesEndpoint` → `ApproachService.GetCombinedApproaches` → `List<CombinedApproach>`
+- `GET /points/{Identifier}` (and `/v1/...`) → `GetPointEndpoint` → `PointService.GetPointsByIdentifier` → `List<PointLookupResult>`
 
-The three airport-keyed endpoints uppercase the `AirportId` before lookup, and all three services try `Port.Identifier` first then fall back to `Port.Designator`. Keep them in sync — if you add metadata to one, add it to all three; the scaffolding is deliberately identical and diff-reviewable side-by-side. All endpoints return responses via the FastEndpoints 7 `Send.OkAsync(...)` API, not the older `SendAsync`.
+The three airport-keyed endpoints uppercase the `AirportId` before lookup, and all three services try `Port.Identifier` first then fall back to `Port.Designator`. Keep them in sync — if you add metadata to one, add it to all three; the scaffolding is deliberately identical and diff-reviewable side-by-side. All endpoints return responses via the FastEndpoints 8 `Send.OkAsync(...)` API, not the older `SendAsync`. Each `Configure()` also sets an OpenAPI `Summary(...)` — keep those populated when adding or renaming endpoints because they feed the Scalar UI directly.
 
 The points endpoint searches `EnrouteWaypoints`, `AirportTerminalWaypoints`, `HeliportTerminalWaypoints`, `Omnidirects` (VHF navaids), and `Nondirects` (NDBs), returning **all** matches because ARINC 424 identifiers are not globally unique (e.g. `JFK` is a VOR-DME and a terminal waypoint). Each result carries a `Type` discriminator; terminal waypoints and terminal VORs also carry an `AirportIdentifier`. `Data424.Waypoints` is intentionally skipped — per the arinc424 docs it's a superset of the three typed sub-collections, and iterating it would produce duplicates.
 
-CORS is wide open: `Program.cs:25` calls `AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()`. Any future auth, cookie, or hosting work needs to revisit this before it becomes a problem.
+CORS is wide open: `Program.cs:50` calls `AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()`. Any future auth, cookie, or hosting work needs to revisit this before it becomes a problem.
 
-Response shape: `CombinedArrival` / `CombinedDeparture` / `CombinedApproach` live alongside their services; the shared `CombinedSequence` (transition name + `TransitionType` stringified from `sequence.Types`) lives in `Services/Models/CombinedSequence.cs` since all three services use it. Each sequence contains `Point`s (`Services/Models/Point.cs`) with nullable `Identifier`/`Latitude`/`Longitude`, altitude min/max, `LegType`, `Course`, and `Descriptions: string[]`. Note `sequence.Types` is plural in `arinc424` 0.3.2 — renamed from `Type` during the upgrade — and `.ToString()` on it produces a comma-separated flags string (e.g. `"Runway, AreaNavigation"`), which is a breaking change from the single-value format pre-upgrade.
+Response shape: `CombinedArrival` / `CombinedDeparture` / `CombinedApproach` live alongside their services; the shared `CombinedSequence` (transition name + `TransitionType` stringified from `sequence.Types`) lives in `Services/Models/CombinedSequence.cs` since all three services use it. Each sequence contains `Point`s (`Services/Models/Point.cs`) with nullable `Identifier`/`Latitude`/`Longitude`, altitude min/max, `LegType`, `Course`, and `Descriptions: string[]`. Note `sequence.Types` is plural in `arinc424` 0.3.x — renamed from `Type` during the upgrade — and `.ToString()` on it produces a comma-separated flags string (e.g. `"Runway, AreaNavigation"`), which is a breaking change from the single-value format pre-upgrade.
 
 **Point nullability and leg metadata:** `Point.Fix`-derived fields (`Identifier`, `Latitude`, `Longitude`) are null for path-terminator legs that don't anchor to a waypoint (CA, VA, FM, CD, CI, CR, VD, VI, VM, VR, HA, HF, HM, PI). `Point.LegType` identifies the leg kind, `Point.Course` gives the outbound magnetic course, and `Point.Descriptions` carries ARINC 424 Waypoint Description Code flags (IAF, IF, FAF, MAP, FlyOver, MissedApproachFirstLeg, InitialDeparture, etc.) split into a `string[]`. Clients must handle the null fields; a SID will typically start with a fix-less `CA`/`VA` leg.
 
-**`ProcedurePoint.Descriptions` is `[Obsolete]` in arinc424 0.3.2** with the author's note "maybe split to 4 enums for SID/STAR/Approach and Airway?" — this is the only deprecated symbol in the DLL, and no replacement ships yet. All three services read it; migrate at the next arinc424 upgrade.
+**`ProcedurePoint.Descriptions` is `[Obsolete]` in arinc424 0.3.x** with the author's note "maybe split to 4 enums for SID/STAR/Approach and Airway?" — this is the only deprecated symbol in the DLL, and no replacement ships yet. All three procedure services read it; migrate at the next arinc424 upgrade.
+
+### OpenAPI and Scalar UI
+
+`Program.cs` registers `SwaggerDocument` (NSwag via `FastEndpoints.Swagger`) and serves:
+
+- `GET /openapi/v1.json` — generated OpenAPI 3 document (`app.UseOpenApi` with `c.Path = "/openapi/{documentName}.json"`).
+- `GET /scalar/v1` — Scalar API reference UI (`Scalar.AspNetCore` 2.13.x; telemetry disabled, Purple/Modern theme, `SchemaPropertyOrder.Preserve` so the JSON shape matches the source DTO order).
+
+`Swagger/TagOrderProcessor.cs` is an NSwag `IDocumentProcessor` that pins configured tag names (currently `"V1"`) to the top of the tag list and sorts the rest alphabetically — register it via `s.DocumentProcessors.Add(new TagOrderProcessor("V1"))` in the `SwaggerDocument` options. If you add a new API version or tag group, update the pinned list here so Scalar renders the groups in a stable order.
 
 ### Altitude handling
 
@@ -59,4 +68,6 @@ Response shape: `CombinedArrival` / `CombinedDeparture` / `CombinedApproach` liv
 
 ## External dependencies
 
-Upstream CIFP source: `https://external-api.faa.gov/apra/cifp/chart` (FAA APRA) returns a `ProductSet` XML whose `edition/product/@url` points at the current CIFP zip. The `arinc424` NuGet package owns `Data424`, `Altitude`, `AltitudeDescription`, and related types referenced throughout `Services/`.
+- Upstream CIFP source: `https://external-api.faa.gov/apra/cifp/chart` (FAA APRA) returns a `ProductSet` XML whose `edition/product/@url` points at the current CIFP zip.
+- `arinc424` (0.3.3) owns `Data424`, `Altitude`, `AltitudeDescription`, and related types referenced throughout `Services/`.
+- `FastEndpoints` / `FastEndpoints.Swagger` (8.1.0), `Coravel` (6.0.2), `Scalar.AspNetCore` (2.13.22). Keep these aligned when upgrading — a FastEndpoints major bump in particular changes the `Send*` surface.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Response shape: `CombinedArrival` / `CombinedDeparture` / `CombinedApproach` liv
 
 ### Altitude handling
 
-`AltitudeConverter.ToAltitudeLimitsStrings` maps the ARINC 424 `AltitudeDescription` enum into `(min, max)` strings via `AltitudeFormatter`. All currently-known enum cases are handled (glide/vertical/optional variants were added on this branch for approaches) and the `_ =>` fallthrough is commented out. That means a future `arinc424` release that introduces a new enum value will throw `SwitchExpressionException` at runtime rather than `ArgumentOutOfRangeException` — if you see one, add the case here rather than re-adding a catch-all.
+`AltitudeConverter.ToAltitudeLimitsStrings` maps the ARINC 424 `AltitudeDescription` enum into `(min, max)` strings via `AltitudeFormatter`. All currently-known enum cases are handled (glide/vertical/optional variants were added on this branch for approaches), with a `_ => throw new ArgumentOutOfRangeException(...)` catch-all matching the pattern in `AltitudeFormatter`. A future `arinc424` release that introduces a new enum value will surface as an `ArgumentOutOfRangeException` at runtime — add the case here when you see one.
 
 ## External dependencies
 

--- a/Endpoints/GetApproaches.cs
+++ b/Endpoints/GetApproaches.cs
@@ -13,8 +13,14 @@ public class GetApproachesEndpoint(ApproachService approachService)
 {
     public override void Configure()
     {
-        Get("/approaches/{AirportId}");
+        Get("/approaches/{AirportId}", "/v1/approaches/{AirportId}");
         AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "List instrument approaches for an airport";
+            s.Description = "Returns all combined approach procedures for the given ICAO/FAA airport identifier.";
+            s.Response<List<CombinedApproach>>(200, "Combined approaches for the airport");
+        });
     }
 
     public override Task HandleAsync(GetApproachesRequest req, CancellationToken ct)

--- a/Endpoints/GetPoint.cs
+++ b/Endpoints/GetPoint.cs
@@ -13,8 +13,15 @@ public class GetPointEndpoint(PointService pointService) : Endpoint<GetPointRequ
 {
     public override void Configure()
     {
-        Get("/points/{Identifier}");
+        Get("/points/{Identifier}", "/v1/points/{Identifier}");
         AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "Look up navigation points by identifier";
+            s.Description = "Returns all navigation points (waypoints, VHF navaids, NDBs) matching the given ARINC 424 identifier. " +
+                            "Identifiers are not globally unique, so multiple results may be returned with a Type discriminator. ";
+            s.Response<List<PointLookupResult>>(200, "Matching points (possibly multiple per identifier)");
+        });
     }
 
     public override Task HandleAsync(GetPointRequest req, CancellationToken ct)

--- a/Endpoints/GetSids.cs
+++ b/Endpoints/GetSids.cs
@@ -12,8 +12,14 @@ public class GetSidsEndpoint(DepartureService departureService) : Endpoint<GetSi
 {
     public override void Configure()
     {
-        Get("/departures/{AirportId}");
+        Get("/departures/{AirportId}", "/v1/departures/{AirportId}");
         AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "List SIDs (departure procedures) for an airport";
+            s.Description = "Returns all SIDs for the given ICAO/FAA airport identifier.";
+            s.Response<List<CombinedDeparture>>(200, "Combined SIDs for the airport");
+        });
     }
 
     public override Task HandleAsync(GetSidsRequest req, CancellationToken ct)

--- a/Endpoints/GetStars.cs
+++ b/Endpoints/GetStars.cs
@@ -12,8 +12,14 @@ public class GetStarsEndpoint(ArrivalService arrivalService) : Endpoint<GetStars
 {
     public override void Configure()
     {
-        Get("/arrivals/{AirportId}");
+        Get("/arrivals/{AirportId}", "/v1/arrivals/{AirportId}");
         AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "List STARs (arrival procedures) for an airport";
+            s.Description = "Returns all STARs for the given ICAO/FAA airport identifier.";
+            s.Response<List<CombinedArrival>>(200, "Combined STARs for the airport");
+        });
     }
 
     public override Task HandleAsync(GetStarsRequest req, CancellationToken ct)

--- a/NavData.csproj
+++ b/NavData.csproj
@@ -11,6 +11,8 @@
         <PackageReference Include="arinc424" Version="0.3.2"/>
         <PackageReference Include="Coravel" Version="6.0.2"/>
         <PackageReference Include="FastEndpoints" Version="7.1.1"/>
+        <PackageReference Include="FastEndpoints.Swagger" Version="7.1.1"/>
+        <PackageReference Include="Scalar.AspNetCore" Version="2.10.0"/>
     </ItemGroup>
 
 </Project>

--- a/NavData.csproj
+++ b/NavData.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Coravel" Version="6.0.2"/>
         <PackageReference Include="FastEndpoints" Version="8.1.0"/>
         <PackageReference Include="FastEndpoints.Swagger" Version="8.1.0"/>
-        <PackageReference Include="Scalar.AspNetCore" Version="2.10.0"/>
+        <PackageReference Include="Scalar.AspNetCore" Version="2.13.22"/>
     </ItemGroup>
 
 </Project>

--- a/NavData.csproj
+++ b/NavData.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="arinc424" Version="0.3.2"/>
+        <PackageReference Include="arinc424" Version="0.3.3"/>
         <PackageReference Include="Coravel" Version="6.0.2"/>
         <PackageReference Include="FastEndpoints" Version="7.1.1"/>
         <PackageReference Include="FastEndpoints.Swagger" Version="7.1.1"/>

--- a/NavData.csproj
+++ b/NavData.csproj
@@ -10,8 +10,8 @@
     <ItemGroup>
         <PackageReference Include="arinc424" Version="0.3.3"/>
         <PackageReference Include="Coravel" Version="6.0.2"/>
-        <PackageReference Include="FastEndpoints" Version="7.1.1"/>
-        <PackageReference Include="FastEndpoints.Swagger" Version="7.1.1"/>
+        <PackageReference Include="FastEndpoints" Version="8.1.0"/>
+        <PackageReference Include="FastEndpoints.Swagger" Version="8.1.0"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.10.0"/>
     </ItemGroup>
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,12 @@
 ﻿using Coravel;
 using FastEndpoints;
+using FastEndpoints.Swagger;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using NavData.Services;
+using NavData.Swagger;
+using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder();
 
@@ -21,9 +25,33 @@ builder.Services.AddScoped<PointService>();
 builder.Services.AddControllers();
 
 builder.Services.AddFastEndpoints();
+builder.Services.SwaggerDocument(o =>
+{
+    o.DocumentSettings = s =>
+    {
+        s.DocumentName = "v1";
+        s.Title = "NavDataApi";
+        s.Version = "v1";
+        s.DocumentProcessors.Add(new TagOrderProcessor("V1"));
+    };
+});
 
 var app = builder.Build();
 app.UseFastEndpoints();
+app.UseOpenApi(c => c.Path = "/openapi/{documentName}.json");
+app.MapGet("/scalar-config.js", () => Results.Text(
+        "export default { telemetry: false };",
+        contentType: "application/javascript"))
+   .ExcludeFromDescription();
+app.MapScalarApiReference(o =>
+{
+    o.AddDocument(documentName: "v1", title: "v1", isDefault: false);
+    o.Layout = ScalarLayout.Modern;
+    o.Theme = ScalarTheme.Purple;
+    o.Title = "NavDataApi";
+    o.SchemaPropertyOrder = PropertyOrder.Preserve;
+    o.JavaScriptConfiguration = "/scalar-config.js";
+});
 app.UseCors(corsBuilder => corsBuilder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
 app.Services.UseScheduler(scheduler => { scheduler.Schedule<CifpUpdateService>().Hourly().RunOnceAtStart(); });
 app.Run();

--- a/Program.cs
+++ b/Program.cs
@@ -2,7 +2,6 @@
 using FastEndpoints;
 using FastEndpoints.Swagger;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using NavData.Services;
 using NavData.Swagger;
@@ -39,10 +38,6 @@ builder.Services.SwaggerDocument(o =>
 var app = builder.Build();
 app.UseFastEndpoints();
 app.UseOpenApi(c => c.Path = "/openapi/{documentName}.json");
-app.MapGet("/scalar-config.js", () => Results.Text(
-        "export default { telemetry: false };",
-        contentType: "application/javascript"))
-   .ExcludeFromDescription();
 app.MapScalarApiReference(o =>
 {
     o.AddDocument(documentName: "v1", title: "v1", isDefault: false);
@@ -50,7 +45,7 @@ app.MapScalarApiReference(o =>
     o.Theme = ScalarTheme.Purple;
     o.Title = "NavDataApi";
     o.SchemaPropertyOrder = PropertyOrder.Preserve;
-    o.JavaScriptConfiguration = "/scalar-config.js";
+    o.Telemetry = false;
 });
 app.UseCors(corsBuilder => corsBuilder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
 app.Services.UseScheduler(scheduler => { scheduler.Schedule<CifpUpdateService>().Hourly().RunOnceAtStart(); });

--- a/Services/ApproachService.cs
+++ b/Services/ApproachService.cs
@@ -49,7 +49,7 @@ public class ApproachService(CifpService cifpService)
 
                 var combinedSequence = new CombinedSequence
                 {
-                    Transition = sequence.Transition,
+                    Transition = sequence.Transition ?? string.Empty,
                     TransitionType = sequence.Types.ToString(),
                     Points = points
                 };

--- a/Services/ArrivalService.cs
+++ b/Services/ArrivalService.cs
@@ -49,7 +49,7 @@ public class ArrivalService(CifpService cifpService)
 
                 var combinedSequence = new CombinedSequence
                 {
-                    Transition = sequence.Transition,
+                    Transition = sequence.Transition ?? string.Empty,
                     TransitionType = sequence.Types.ToString(),
                     Points = points
                 };

--- a/Services/CifpService.cs
+++ b/Services/CifpService.cs
@@ -6,8 +6,8 @@ namespace NavData.Services;
 public class CifpService
 {
     public Data424? Data { get; private set; }
-    public FrozenDictionary<Record424, Diagnostic[]> Invalid { get; private set; }
-    public string[] Skipped { get; private set; }
+    public FrozenDictionary<Record424, Diagnostic[]> Invalid { get; private set; } = FrozenDictionary<Record424, Diagnostic[]>.Empty;
+    public string[] Skipped { get; private set; } = [];
 
     public bool UpdateCifp(IAsyncEnumerable<string> strings)
     {

--- a/Services/DepartureService.cs
+++ b/Services/DepartureService.cs
@@ -48,7 +48,7 @@ public class DepartureService(CifpService cifpService)
 
                 var combinedSequence = new CombinedSequence
                 {
-                    Transition = sequence.Transition,
+                    Transition = sequence.Transition ?? string.Empty,
                     TransitionType = sequence.Types.ToString(),
                     Points = points
                 };

--- a/Services/Utilities/AltitudeConverter.cs
+++ b/Services/Utilities/AltitudeConverter.cs
@@ -26,8 +26,8 @@ public static class AltitudeConverter
             AltitudeDescription.OptionalAtAbove => (formatted1, formatted2),
             AltitudeDescription.AtVerticalSecondAtAboveFirst => (formatted1, null),
             AltitudeDescription.AtVerticalSecondAtFirst => (formatted1, formatted1),
-            AltitudeDescription.AtVerticalSecondAtBelowFirst => (null, formatted1)
-            //_ => throw new ArgumentOutOfRangeException(nameof(altitudeDescription), altitudeDescription, null)
+            AltitudeDescription.AtVerticalSecondAtBelowFirst => (null, formatted1),
+            _ => throw new ArgumentOutOfRangeException(nameof(altitudeDescription), altitudeDescription, null)
         };
     }
 }

--- a/Swagger/TagOrderProcessor.cs
+++ b/Swagger/TagOrderProcessor.cs
@@ -1,0 +1,31 @@
+using NSwag;
+using NSwag.Generation.Processors;
+using NSwag.Generation.Processors.Contexts;
+
+namespace NavData.Swagger;
+
+internal sealed class TagOrderProcessor(params string[] pinnedTags) : IDocumentProcessor
+{
+    public void Process(DocumentProcessorContext context)
+    {
+        var tags = context.Document.Operations
+            .SelectMany(o => o.Operation.Tags ?? [])
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        var ordered = new List<OpenApiTag>();
+        foreach (var pinned in pinnedTags)
+        {
+            var match = tags.FirstOrDefault(t => t.Equals(pinned, StringComparison.OrdinalIgnoreCase));
+            if (match is not null) ordered.Add(new OpenApiTag { Name = match });
+        }
+
+        var pinnedSet = ordered.Select(t => t.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        ordered.AddRange(tags
+            .Where(t => !pinnedSet.Contains(t))
+            .OrderBy(t => t, StringComparer.OrdinalIgnoreCase)
+            .Select(name => new OpenApiTag { Name = name }));
+
+        context.Document.Tags = ordered;
+    }
+}


### PR DESCRIPTION
Publishes a machine-readable API contract at /openapi/v1.json and a
browser-friendly explorer at /scalar (Scalar UI, telemetry disabled
via a small JS shim). Each endpoint is now also reachable under
/v1/* so clients can pin to the current contract today, making a
future v2 a no-coordination rollout for any pinned client. The "V1"
tag is pinned to the top of the spec via a small NSwag document
processor; remaining tags sort alphabetically.

Also updates packages and solves warnings