### PR TITLE
Add airport metadata and airways lookup endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 .idea
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ The FAA CIFP data is the single source of truth and is loaded into memory at sta
 ### Service lifetimes (important gotcha)
 
 - `CifpService` — **singleton**, holds the mutable `Data424?`.
-- `ArrivalService` / `DepartureService` / `ApproachService` / `PointService` — **scoped**, depend on `CifpService`. All four use primary constructors and dereference `cifpService.Data` lazily inside their `Get*` methods, throwing if null.
+- `ArrivalService` / `DepartureService` / `ApproachService` / `PointService` / `AirportService` / `AirwayService` — **scoped**, depend on `CifpService`. All use primary constructors and dereference `cifpService.Data` lazily inside their `Get*` methods, throwing if null.
 - Because the local-file fallback was removed, `cifpService.Data` is `null` until the first successful FAA fetch completes. Any request arriving in that window will throw — the services surface it as a clean `Exception("CifpService data is null")` rather than an NPE, but the 500 response is the same either way. If you touch the load flow, preserve the invariant that `Data` is populated before the app starts serving, or add a proper 503 path.
 
 ### Endpoints
@@ -40,12 +40,18 @@ FastEndpoints 8 auto-discovers endpoint classes under `Endpoints/`. Every route 
 - `GET /arrivals/{AirportId}` (and `/v1/...`) → `GetStarsEndpoint` → `ArrivalService.GetCombinedArrivals` → `List<CombinedArrival>`
 - `GET /approaches/{AirportId}` (and `/v1/...`) → `GetApproachesEndpoint` → `ApproachService.GetCombinedApproaches` → `List<CombinedApproach>`
 - `GET /points/{Identifier}` (and `/v1/...`) → `GetPointEndpoint` → `PointService.GetPointsByIdentifier` → `List<PointLookupResult>`
+- `GET /airports/{AirportId}` (and `/v1/...`) → `GetAirportEndpoint` → `AirportService.GetAirportInfo` → `AirportInfo` (returns 404 if not found)
+- `GET /airways/{Identifier}` (and `/v1/...`) → `GetAirwaysEndpoint` → `AirwayService.GetCombinedAirways` → `List<CombinedAirway>`
 
-The three airport-keyed endpoints uppercase the `AirportId` before lookup, and all three services try `Port.Identifier` first then fall back to `Port.Designator`. Keep them in sync — if you add metadata to one, add it to all three; the scaffolding is deliberately identical and diff-reviewable side-by-side. All endpoints return responses via the FastEndpoints 8 `Send.OkAsync(...)` API, not the older `SendAsync`. Each `Configure()` also sets an OpenAPI `Summary(...)` — keep those populated when adding or renaming endpoints because they feed the Scalar UI directly.
+The three procedure endpoints (departures, arrivals, approaches) uppercase the `AirportId` before lookup, and all three services try `Port.Identifier` first then fall back to `Port.Designator`. Keep them in sync — if you add metadata to one, add it to all three; the scaffolding is deliberately identical and diff-reviewable side-by-side. The airport endpoint uses the same dual-lookup pattern but returns a single object or 404 instead of a list. All endpoints return responses via the FastEndpoints 8 `Send.OkAsync(...)` API, not the older `SendAsync`. Each `Configure()` also sets an OpenAPI `Summary(...)` — keep those populated when adding or renaming endpoints because they feed the Scalar UI directly.
 
 The points endpoint searches `EnrouteWaypoints`, `AirportTerminalWaypoints`, `HeliportTerminalWaypoints`, `Omnidirects` (VHF navaids), and `Nondirects` (NDBs), returning **all** matches because ARINC 424 identifiers are not globally unique (e.g. `JFK` is a VOR-DME and a terminal waypoint). Each result carries a `Type` discriminator; terminal waypoints and terminal VORs also carry an `AirportIdentifier`. `Data424.Waypoints` is intentionally skipped — per the arinc424 docs it's a superset of the three typed sub-collections, and iterating it would produce duplicates.
 
 CORS is wide open: `Program.cs:50` calls `AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()`. Any future auth, cookie, or hosting work needs to revisit this before it becomes a problem.
+
+**Airport metadata:** `AirportInfo` lives alongside `AirportService` and exposes: `Identifier` (ICAO), `IcaoCode` (two-char region), `Designator` (IATA, nullable), `Name`, `Latitude`/`Longitude`, `Elevation`, `Variation` (magnetic deviation in degrees), `CourseType` (Magnetic/True), `TimeZone`, `Privacy`, `LongestRunwayLength`, `LongestRunwayType`. All enums are serialized as strings via `.ToString()`.
+
+**Airway response shape:** `CombinedAirway` (identifier + points list) and `AirwayFixPoint` live alongside `AirwayService`. Unlike procedure points, airway `Fix` is never null — all fields (`Identifier`, `Latitude`, `Longitude`) are non-nullable. Altitudes use `AltitudeFormatter.FormatAltitude()` directly (no `AltitudeDescription` discriminator). Each point carries `Type` (AirwayType), `Level` (High/Low), `Restriction` (None/Forward/Backward), inbound/outbound courses, `DistanceFrom` (nm), three altitude fields (`Minimum`, `Minimum2`, `Maximum`), and `Descriptions` flags.
 
 Response shape: `CombinedArrival` / `CombinedDeparture` / `CombinedApproach` live alongside their services; the shared `CombinedSequence` (transition name + `TransitionType` stringified from `sequence.Types`) lives in `Services/Models/CombinedSequence.cs` since all three services use it. Each sequence contains `Point`s (`Services/Models/Point.cs`) with nullable `Identifier`/`Latitude`/`Longitude`, altitude min/max, `LegType`, `Course`, and `Descriptions: string[]`. Note `sequence.Types` is plural in `arinc424` 0.3.x — renamed from `Type` during the upgrade — and `.ToString()` on it produces a comma-separated flags string (e.g. `"Runway, AreaNavigation"`), which is a breaking change from the single-value format pre-upgrade.
 

--- a/Endpoints/GetAirport.cs
+++ b/Endpoints/GetAirport.cs
@@ -1,0 +1,36 @@
+using FastEndpoints;
+using NavData.Services;
+
+namespace NavData.Endpoints;
+
+public class GetAirportRequest
+{
+    public string AirportId { get; set; } = string.Empty;
+}
+
+public class GetAirportEndpoint(AirportService airportService) : Endpoint<GetAirportRequest, AirportInfo>
+{
+    public override void Configure()
+    {
+        Get("/airports/{AirportId}", "/v1/airports/{AirportId}");
+        AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "Get airport metadata";
+            s.Description = "Returns metadata for the given ICAO/FAA airport identifier, including coordinates, elevation, magnetic variation, and runway information.";
+            s.Response<AirportInfo>(200, "Airport metadata");
+            s.Response(404, "Airport not found");
+        });
+    }
+
+    public override Task HandleAsync(GetAirportRequest req, CancellationToken ct)
+    {
+        var airport = airportService.GetAirportInfo(req.AirportId.ToUpperInvariant());
+        if (airport is null)
+        {
+            return Send.NotFoundAsync(ct);
+        }
+
+        return Send.OkAsync(airport, ct);
+    }
+}

--- a/Endpoints/GetAirways.cs
+++ b/Endpoints/GetAirways.cs
@@ -1,0 +1,30 @@
+using FastEndpoints;
+using NavData.Services;
+
+namespace NavData.Endpoints;
+
+public class GetAirwaysRequest
+{
+    public string Identifier { get; set; } = string.Empty;
+}
+
+public class GetAirwaysEndpoint(AirwayService airwayService) : Endpoint<GetAirwaysRequest, List<CombinedAirway>>
+{
+    public override void Configure()
+    {
+        Get("/airways/{Identifier}", "/v1/airways/{Identifier}");
+        AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "Look up an airway by identifier";
+            s.Description = "Returns the sequence of fixes for the given airway identifier (e.g. J584, V23), including altitude limits, courses, and classification.";
+            s.Response<List<CombinedAirway>>(200, "Airways matching the identifier, each with their fix sequences");
+        });
+    }
+
+    public override Task HandleAsync(GetAirwaysRequest req, CancellationToken ct)
+    {
+        var airways = airwayService.GetCombinedAirways(req.Identifier.ToUpperInvariant()).ToList();
+        return Send.OkAsync(airways, ct);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -20,6 +20,8 @@ builder.Services.AddScoped<ArrivalService>();
 builder.Services.AddScoped<DepartureService>();
 builder.Services.AddScoped<ApproachService>();
 builder.Services.AddScoped<PointService>();
+builder.Services.AddScoped<AirportService>();
+builder.Services.AddScoped<AirwayService>();
 
 builder.Services.AddControllers();
 

--- a/Services/AirportService.cs
+++ b/Services/AirportService.cs
@@ -1,0 +1,61 @@
+namespace NavData.Services;
+
+public class AirportService(CifpService cifpService)
+{
+    public AirportInfo? GetAirportInfo(string airportIdentifier)
+    {
+        if (cifpService.Data is null)
+        {
+            throw new Exception("CifpService data is null");
+        }
+
+        var airport = cifpService.Data.Airports.FirstOrDefault(a =>
+            a.Identifier.Equals(airportIdentifier, StringComparison.InvariantCultureIgnoreCase));
+
+        if (airport is null)
+        {
+            airport = cifpService.Data.Airports.FirstOrDefault(a =>
+                a.Designator is not null && a.Designator.Equals(airportIdentifier,
+                    StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        if (airport is null)
+        {
+            return null;
+        }
+
+        return new AirportInfo
+        {
+            Identifier = airport.Identifier,
+            IcaoCode = airport.Icao.ToString(),
+            Designator = airport.Designator,
+            Name = airport.Name,
+            Latitude = airport.Coordinates.Latitude,
+            Longitude = airport.Coordinates.Longitude,
+            Elevation = airport.Elevation,
+            Variation = airport.Variation,
+            CourseType = airport.CourseType.ToString(),
+            TimeZone = airport.TimeZone,
+            Privacy = airport.Privacy.ToString(),
+            LongestRunwayLength = airport.LongestRunwayLength,
+            LongestRunwayType = airport.LongestRunwayType.ToString()
+        };
+    }
+}
+
+public class AirportInfo
+{
+    public string Identifier { get; set; } = string.Empty;
+    public string IcaoCode { get; set; } = string.Empty;
+    public string? Designator { get; set; }
+    public string? Name { get; set; }
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+    public int Elevation { get; set; }
+    public float Variation { get; set; }
+    public string CourseType { get; set; } = string.Empty;
+    public string? TimeZone { get; set; }
+    public string Privacy { get; set; } = string.Empty;
+    public int LongestRunwayLength { get; set; }
+    public string LongestRunwayType { get; set; } = string.Empty;
+}

--- a/Services/AirwayService.cs
+++ b/Services/AirwayService.cs
@@ -1,0 +1,67 @@
+using NavData.Services.Utilities;
+
+namespace NavData.Services;
+
+public class AirwayService(CifpService cifpService)
+{
+    public IEnumerable<CombinedAirway> GetCombinedAirways(string identifier)
+    {
+        if (cifpService.Data is null)
+        {
+            throw new Exception("CifpService data is null");
+        }
+
+        var airways = cifpService.Data.Airways.Where(a =>
+                a.Identifier.Equals(identifier, StringComparison.InvariantCultureIgnoreCase))
+            .ToList();
+
+        foreach (var airway in airways)
+        {
+            var points = airway.Sequence.Select(p => new AirwayFixPoint
+            {
+                Identifier = p.Fix.Identifier,
+                Latitude = p.Fix.Coordinates.Latitude,
+                Longitude = p.Fix.Coordinates.Longitude,
+                Type = p.Type.ToString(),
+                Level = p.LevelType.ToString(),
+                Restriction = p.Restriction.ToString(),
+                OutboundCourse = p.Out.Value,
+                InboundCourse = p.In.Value,
+                DistanceFrom = p.DistanceFrom,
+                Minimum = AltitudeFormatter.FormatAltitude(p.Minimum),
+                Minimum2 = AltitudeFormatter.FormatAltitude(p.Minimum2),
+                Maximum = AltitudeFormatter.FormatAltitude(p.Maximum),
+                Descriptions = p.Descriptions == 0 ? [] : p.Descriptions.ToString().Split(", ")
+            }).ToList();
+
+            yield return new CombinedAirway
+            {
+                AirwayIdentifier = airway.Identifier,
+                Points = points
+            };
+        }
+    }
+}
+
+public class CombinedAirway
+{
+    public string AirwayIdentifier { get; set; } = string.Empty;
+    public List<AirwayFixPoint> Points { get; set; } = [];
+}
+
+public class AirwayFixPoint
+{
+    public string Identifier { get; set; } = string.Empty;
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string Level { get; set; } = string.Empty;
+    public string Restriction { get; set; } = string.Empty;
+    public double OutboundCourse { get; set; }
+    public double InboundCourse { get; set; }
+    public double DistanceFrom { get; set; }
+    public string? Minimum { get; set; }
+    public string? Minimum2 { get; set; }
+    public string? Maximum { get; set; }
+    public string[] Descriptions { get; set; } = [];
+}


### PR DESCRIPTION
Expose airport metadata (ICAO/IATA codes, coordinates, elevation, magnetic variation, course type, runway info) via GET /airports/{id} and airway fix sequences (altitude limits, courses, classifications) via GET /airways/{id}. Both follow existing endpoint patterns with dual route registration and OpenAPI summaries.